### PR TITLE
Fixing semicolon insertion example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,12 +22,14 @@
 
 ````JavaScript
 // Returns undefined. No warning
-return { 
-         status: true
-     };
+return 
+{
+    status: true
+};
+
 //  can be avoided by moving the bracket to the top line
-   return {
-         status: true
+return {
+    status: true
 };
 ````
 - Reserved Words


### PR DESCRIPTION
The example for the undesired semicolon insertion (i.e. line 25) still had the curly brace on the same line as the return statement.  I have moved it to the next line so it demonstrates the problem.