### PR TITLE
Fix syntax error 'var = this'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -385,7 +385,7 @@ Private:
 
 ````JavaScript
 function Constructor(…){
-	var = this
+	var self = this;
 	var membername = value;
 	function membername(…) {…}
 }


### PR DESCRIPTION
Small syntax error -- no variable name given -- in the private object values example.